### PR TITLE
Add filtering to attempts by tag

### DIFF
--- a/app/Http/Controllers/AttemptController.php
+++ b/app/Http/Controllers/AttemptController.php
@@ -23,15 +23,24 @@ class AttemptController extends Controller
      *     summary="List attempts",
      *     description="Return all attempts for the current user, paginated",
      *     tags={"attempt"},
+     *     @OA\Parameter(
+     *         name="tags",
+     *         in="query",
+     *         @OA\Schema(type="string")
+     *     )
      *     @OA\Response(response="200", description="Success"),
      *     @OA\Response(response="403", description="Not permitted"),
      *     security={{"bearerAuth":{}}}
      * )
      */
-    public function index()
+    public function index(Request $request)
     {
+        if ($request->input('tags')) {
+            $tags = explode(',', $request->input('tags'));
+        }
+
         try {
-            $attempts = $this->service->all();
+            $attempts = $this->service->all($tags ?? null);
         } catch (UnauthorizedException) {
             return $this->handleForbidden();
         }

--- a/app/Models/Attempt.php
+++ b/app/Models/Attempt.php
@@ -8,6 +8,7 @@ use App\Enums\QuestionType;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Collection;
 
 /**
@@ -24,6 +25,7 @@ use Illuminate\Support\Collection;
  * @property string answered_at
  * @property Collection older_attempts
  * @property Collection newer_attempts
+ * @property Collection keywords
  */
 class Attempt extends Model
 {
@@ -85,6 +87,11 @@ class Attempt extends Model
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
+    }
+
+    public function keywords(): HasMany
+    {
+        return $this->hasMany(Keyword::class);
     }
 
     public function getOlderAttemptsAttribute(): Collection

--- a/app/Models/Keyword.php
+++ b/app/Models/Keyword.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * @property string name
+ */
+class Keyword extends Model
+{
+    use HasFactory;
+
+    protected $table = 'attempt_keyword';
+    public $timestamps = false;
+
+    protected $fillable = [
+        'name',
+    ];
+
+    public function attempts(): BelongsTo
+    {
+        return $this->belongsTo(Attempt::class);
+    }
+}

--- a/app/Transformers/AttemptTransformer.php
+++ b/app/Transformers/AttemptTransformer.php
@@ -4,6 +4,7 @@ namespace App\Transformers;
 
 use App\Models\Attempt;
 use App\Models\AttemptAnswer;
+use App\Models\Keyword;
 use Carbon\Carbon;
 use League\Fractal\TransformerAbstract;
 
@@ -26,7 +27,9 @@ class AttemptTransformer extends TransformerAbstract
                     'is_correct' => $answer->getIsCorrect(),
                 ];
             }),
-            'tags' => explode(',', $attempt->tags),
+            'keywords' => $attempt->keywords->map(function (Keyword $keyword) {
+                return $keyword->name;
+            }),
             'older_attempts' => $attempt->older_attempts ? $attempt->older_attempts->map(function (Attempt $olderAttempt) {
                 return (new HistoricAttemptTransformer())->transform($olderAttempt);
             }) : [],

--- a/database/factories/AttemptFactory.php
+++ b/database/factories/AttemptFactory.php
@@ -37,7 +37,6 @@ class AttemptFactory extends Factory
             'points_earned' => rand(1, 8),
             'answered_at' => now()->subMinutes(rand(30,6000)),
             'answers' => json_encode($answers),
-            'tags' => implode(',', fake()->words(rand(1, 4)))
         ];
     }
 }

--- a/database/factories/KeywordFactory.php
+++ b/database/factories/KeywordFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Answer;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Answer>
+ */
+class KeywordFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'name' => fake()->word(),
+        ];
+    }
+}

--- a/database/migrations/2024_08_26_072800_create_attempts_table.php
+++ b/database/migrations/2024_08_26_072800_create_attempts_table.php
@@ -18,7 +18,6 @@ return new class extends Migration
             $table->string('question');
             $table->enum('question_type', QuestionType::toArray());
             $table->json('answers');
-            $table->string('tags');
             $table->enum('correctness', Correctness::toArray())->default(Correctness::NONE);
             $table->enum('difficulty', Difficulty::toArray())->default(Difficulty::EASY);
             $table->unsignedInteger('points_earned')->default(0);

--- a/database/migrations/2025_02_18_100500_create_attempt_keyword_table.php
+++ b/database/migrations/2025_02_18_100500_create_attempt_keyword_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use App\Models\Attempt;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('attempt_keyword', function (Blueprint $table) {
+            $table->id();
+            $table->foreignIdFor(Attempt::class);
+            $table->string('name');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('attempt_keyword');
+    }
+};


### PR DESCRIPTION
Created a Keyword model separate from Tag to do this, since I want to remove the binding from Tags, which can be changed or deleted at any time. This means that attempts can be filtered independently of the flashcards they are/were associated with and which tags those flashcards are/were associated with as well. So even if you go ahead and burn down all your datasets, you can still look at and filter historic data for how you did (unless you delete the attempts themselves, of course)