### PR TITLE
Feature/roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,11 @@ Disclaimer: Big ol' chunks of what's written below isn't complete yet (including
 ## Flashcards
 
 Create flashcards of different types:
-1. statement - these have no answers to select, and just give you a fact/statement/whatever to digest
-2. question - these have multiple answers and only one correct answer
-3. multiple-choice - these have multiple answers with two or more correct answers
+1. statement - these give you a fact/statement/whatever to digest, you get to choose if the statement is true or false
+2. single - these have multiple answers and only one correct answer
+3. multiple - these have multiple answers with two or more correct answers
+
+Functionally 2 and 3 are pretty indistinguishable, though there's additional scoring logic applied (see below) for 3 vs 2.
 
 Flashcards have tags, which you can think of like subjects or topics.
 
@@ -26,7 +28,7 @@ If you answer incorrectly, then it will be reset to 'easy'
 
 ### Scoring
 
-Each time you provide a correct answer, you'll get an increase in score. In the case of a multiple choice, you'll only get a score increase if you get ALL the correct answers and NONE of the incorrect ones, so think carefully...
+Each time you provide a correct answer, you'll get an increase in score. In the case of a multiple choice, you'll only get a score increase if you get ALL the correct answers and NONE of the incorrect ones, so think carefully... You get more points for these types of questions though!
 
 ## Running it
 
@@ -38,7 +40,9 @@ Each time you provide a correct answer, you'll get an increase in score. In the 
    2. `php artisan seed --class=FlashcardSeeder` will make some flashcards of different types for you to try out
 5. `php artisan serve` and you can check it out in Swagger
 
-To use the endpoints, you'll need to hit the login one first. The seeded user's email is `f2@test.com` and their password is very secure: `password`. I assume you know what you're doing with bearer tokens, or you're going to have Bad Time(tm).
+I generally prefer containerisation with Laravel Sail, so if you know what you're doing, you can just do a `sail up -d` and then all the commands above are largely the same, except instead of `php artisan` you do `sail artisan` instead.
+
+To use the endpoints, you'll need to hit the login one first. The seeded username is `demo` and their password is very secure: `password`. I assume you know what you're doing with bearer tokens, or you're going to have Bad Time(tm).
 
 ### Known issues
 
@@ -50,14 +54,13 @@ If you want to import your own questions to try it out - something I recommend i
 
 First, you need a `questions.json` file. You can put it into the `/storage/import` directory so the command can find it.
 
-Read through the following sections for formatting constraints, then when you're ready, you can run `php artisan app:import-flashcards {user}`, replacing `{user}` with the id of your seeded/created user in the DB.
+Read through the following sections for formatting constraints, then when you're ready, you can run `php artisan app:import-flashcards {username}`, replacing `{username}` with whatever you want. If it's a username of an existing user you have in your DB, it will assign the questions to them.
 
 #### For statement (i.e. true/false) questions
 ```json
 [
     {
         "text": "Two plus two is seven",
-        "type": "statement",
         "is_true": false,
         "explanation": "The correct answer is four.",
         "tags": [
@@ -67,7 +70,7 @@ Read through the following sections for formatting constraints, then when you're
 ]
 ```
 
-Statements require no answers, only a flag to stipulate whether the statement itself is true or not. 
+Statements require no answers, only a flag to stipulate whether the statement itself is true or not. The lack of an answers array is what the importer will look for in terms of processing the data correctly.
 
 If the statement is false, it is recommended to provide an `explanation` so the user can know what the correct answer would be if it were to come up as another type of question.
 
@@ -76,7 +79,6 @@ If the statement is false, it is recommended to provide an `explanation` so the 
 [
     {
         "text": "What is two plus two?",
-        "type": "single",
         "answers": [
             {
                 "text": "Four",
@@ -95,7 +97,7 @@ If the statement is false, it is recommended to provide an `explanation` so the 
 ]
 ```
 
-You can set the type to `multiple` if you intend to have multiple answers in the set that are correct. The `explanation` is optional, but recommended for incorrect answers. It is useful for correct ones to provide more context if desired.
+The `explanation` is optional, but recommended for incorrect answers. It can also be useful for correct ones to provide more context if desired.
 
 ## The TODO list
 

--- a/app/Console/Commands/ImportFlashcards.php
+++ b/app/Console/Commands/ImportFlashcards.php
@@ -6,6 +6,7 @@ use App\Enums\Status;
 use App\Enums\TagColour;
 use App\Models\Answer;
 use App\Models\Flashcard;
+use App\Models\Role;
 use App\Models\Tag;
 use App\Models\User;
 use Illuminate\Console\Command;
@@ -26,6 +27,13 @@ class ImportFlashcards extends Command
             $user = User::factory()->create([
                 'username' => $this->argument('username')
             ]);
+        }
+
+        $role = Role::where('code', 'advanced_user')->first();
+        $userRoles = $user->roles->pluck('code')->toArray();
+
+        if(!in_array($role->code, $userRoles)) {
+            $user->roles()->attach($role);
         }
 
         $data = Storage::disk('import')->json('questions.json');

--- a/app/Console/Commands/ImportFlashcards.php
+++ b/app/Console/Commands/ImportFlashcards.php
@@ -14,19 +14,19 @@ use Illuminate\Support\Facades\Storage;
 
 class ImportFlashcards extends Command
 {
-    protected $signature = 'app:import-flashcards {user}';
+    protected $signature = 'app:import-flashcards {username}';
 
     protected $description = 'Imports flashcards from the /public/import/ directory - pop in a questions.json file ' .
     'and run this. More info can be found in the readme regarding formatting.';
 
     public function handle(): int
     {
-        $user = User::find($this->argument('user'));
+        $user = User::where('username', $this->argument('username'))->first();
 
         if (!$user) {
-            $this->error('User not found.');
-
-            return 1;
+            $user = User::factory()->create([
+                'username' => $this->argument('username')
+            ]);
         }
 
         $data = Storage::disk('import')->json('questions.json');
@@ -105,7 +105,7 @@ class ImportFlashcards extends Command
             $colour = array_rand(TagColour::cases());
             $tag = Tag::firstOrCreate([
                 'name' => $topic,
-                'user_id' => $this->argument('user'),
+                'user_id' => User::where('username', $this->argument('username'))->first()->id,
             ], [
                 'colour' => TagColour::from($colour),
             ]);

--- a/app/Console/Commands/ImportFlashcards.php
+++ b/app/Console/Commands/ImportFlashcards.php
@@ -2,7 +2,6 @@
 
 namespace App\Console\Commands;
 
-use App\Enums\QuestionType;
 use App\Enums\Status;
 use App\Enums\TagColour;
 use App\Models\Answer;
@@ -40,16 +39,10 @@ class ImportFlashcards extends Command
         $json = json_decode(json_encode($data));
 
         foreach ($json as $question) {
-            if (
-                property_exists($question, 'answers')
-                && in_array($question->type, [QuestionType::MULTIPLE->value, QuestionType::SINGLE->value])
-            ) {
+            if (property_exists($question, 'answers')) {
                 $this->createFlashcardWithAnswers($user, $question);
-            } elseif (QuestionType::STATEMENT->value === $question->type) {
-                $this->createStatementFlashcard($user, $question);
             } else {
-                $this->warn('Invalid question type "' . $question->type . '", skipping. Valid types are: ' .
-                    'statement, single, multiple.');
+                $this->createStatementFlashcard($user, $question);
             }
         }
 

--- a/app/Events/UserCreated.php
+++ b/app/Events/UserCreated.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Events;
+
+use App\Models\Role;
+use App\Models\User;
+use Illuminate\Foundation\Events\Dispatchable;
+
+class UserCreated
+{
+    use Dispatchable;
+
+    public function __construct(public User $user)
+    {
+        $user->roles()->attach(Role::where('code', 'user')->first());
+    }
+}

--- a/app/Exceptions/FreeUserFlashcardLimitException.php
+++ b/app/Exceptions/FreeUserFlashcardLimitException.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Exceptions;
+
+use Throwable;
+
+class FreeUserFlashcardLimitException extends BaseException
+{
+    public function __construct()
+    {
+        $this->message = 'Free users have a limit of 10 questions.';
+
+        parent::__construct();
+    }
+}

--- a/app/Http/Controllers/FlashcardController.php
+++ b/app/Http/Controllers/FlashcardController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Exceptions\DraftQuestionsCannotChangeStatusException;
+use App\Exceptions\FreeUserFlashcardLimitException;
 use App\Exceptions\LessThanOneCorrectAnswerException;
 use App\Exceptions\NoEligibleQuestionsException;
 use App\Exceptions\UndeterminedQuestionTypeException;
@@ -96,7 +97,6 @@ class FlashcardController extends Controller
 
         return fractal($flashcardResponse, new FlashcardFullTransformer())->respond();
     }
-
     /**
      * @OA\Post(
      *     path="/api/flashcards",
@@ -114,6 +114,7 @@ class FlashcardController extends Controller
      *         )
      *     ),
      *     @OA\Response(response="200", description="Success"),
+     *     @OA\Response(response="400", description="Free account limitation reached"),
      *     @OA\Response(response="403", description="Not permitted"),
      *     @OA\Response(response="422", description="Validation error"),
      *     security={{"bearerAuth":{}}}
@@ -131,6 +132,12 @@ class FlashcardController extends Controller
             $flashcardResponse = $this->service->store($request->all());
         } catch (UnauthorizedException) {
             return $this->handleForbidden();
+        } catch (FreeUserFlashcardLimitException $e) {
+            return ApiResponse::error(
+                'Free user account limitation',
+                $e->getMessage(),
+                'free_account_limit'
+            );
         } catch (UndeterminedQuestionTypeException $e) {
             return ApiResponse::error(
                 'Undetermined question type',
@@ -149,6 +156,7 @@ class FlashcardController extends Controller
 
         return fractal($flashcardResponse, new FlashcardFullTransformer())->respond();
     }
+
 
     /**
      * @OA\Patch(

--- a/app/Models/Role.php
+++ b/app/Models/Role.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+/**
+ * @property string name
+ * @property string code
+ */
+class Role extends Model
+{
+    public $timestamps = false;
+
+    protected $fillable = [
+        'name',
+        'code'
+    ];
+
+    public function users(): BelongsToMany
+    {
+        return $this->belongsToMany(User::class)->withPivot(['valid_until', 'auto_renew']);
+    }
+}

--- a/app/Models/Role.php
+++ b/app/Models/Role.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 /**
+ * @property int id
  * @property string name
  * @property string code
  */

--- a/app/Models/RoleUser.php
+++ b/app/Models/RoleUser.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Relations\Pivot;
+
+/**
+ * @property string valid_until
+ * @property bool auto_renew
+ */
+class RoleUser extends Pivot
+{
+    public $timestamps = false;
+    public $incrementing = true;
+
+    protected $fillable = [
+        'valid_until',
+        'auto_renew',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'auto_renew' => 'boolean'
+        ];
+    }
+}

--- a/app/Models/RoleUser.php
+++ b/app/Models/RoleUser.php
@@ -5,6 +5,8 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Relations\Pivot;
 
 /**
+ * @property int role_id
+ * @property int user_id
  * @property string valid_until
  * @property bool auto_renew
  */
@@ -14,6 +16,8 @@ class RoleUser extends Pivot
     public $incrementing = true;
 
     protected $fillable = [
+        'role_id',
+        'user_id',
         'valid_until',
         'auto_renew',
     ];

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -4,9 +4,11 @@ namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Support\Collection;
 use Laravel\Sanctum\HasApiTokens;
 use RedExplosion\Sqids\Concerns\HasSqids;
 
@@ -22,6 +24,7 @@ use RedExplosion\Sqids\Concerns\HasSqids;
  * @property int hard_time
  * @property int page_limit
  * @property bool lose_points
+ * @property Collection roles
  *
  * @OA\Schema(
  *     required={"username", "password", "display_name"},
@@ -89,6 +92,11 @@ class User extends Authenticatable
     public function attempts(): HasMany
     {
         return $this->hasMany(Attempt::class);
+    }
+
+    public function roles(): BelongsToMany
+    {
+        return $this->belongsToMany(Role::class)->withPivot(['valid_until', 'auto_renew']);
     }
 
     public function adjustPoints(int $score, $operation = 'add'): static

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
+use App\Events\UserCreated;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -83,6 +84,10 @@ class User extends Authenticatable
             'lose_points' => 'boolean',
         ];
     }
+
+    protected $dispatchesEvents = [
+        'created' => UserCreated::class,
+    ];
 
     public function flashcards(): HasMany
     {

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -54,6 +54,7 @@ class User extends Authenticatable
         'medium_time',
         'hard_time',
         'page_limit',
+        'lose_points',
     ];
 
     /**

--- a/app/Transformers/RoleTransformer.php
+++ b/app/Transformers/RoleTransformer.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Transformers;
+
+use App\Models\Role;
+use Carbon\Carbon;
+use League\Fractal\TransformerAbstract;
+
+class RoleTransformer extends TransformerAbstract
+{
+    public function transform(Role $role): array
+    {
+        return [
+            'name' => $role->name,
+            'code' => $role->code,
+            'valid_until' => $role->pivot->valid_until
+                ? Carbon::parse($role->pivot->valid_until)->toIso8601String()
+                : null,
+            'auto_renew' => $role->pivot->auto_renew,
+        ];
+    }
+}

--- a/app/Transformers/UserTransformer.php
+++ b/app/Transformers/UserTransformer.php
@@ -2,6 +2,7 @@
 
 namespace App\Transformers;
 
+use App\Models\Role;
 use App\Models\User;
 use Carbon\Carbon;
 use League\Fractal\TransformerAbstract;
@@ -12,9 +13,20 @@ class UserTransformer extends TransformerAbstract
     {
         return [
             'id' => $user->sqid,
+            'username' => $user->username,
             'name' => $user->display_name,
             'points' => $user->points,
-            'created_at' => Carbon::parse($user->created_at)->toIso8601String()
+            'created_at' => Carbon::parse($user->created_at)->toIso8601String(),
+            'options' => [
+                'easy_time' => $user->easy_time,
+                'medium_time' => $user->medium_time,
+                'hard_time' => $user->hard_time,
+                'lose_points' => $user->lose_points,
+                'page_limit' => $user->page_limit,
+            ],
+            'roles' => $user->roles->map(function (Role $role) {
+                return (new RoleTransformer)->transform($role);
+            }),
         ];
     }
 }

--- a/app/Transformers/UserTransformer.php
+++ b/app/Transformers/UserTransformer.php
@@ -12,8 +12,7 @@ class UserTransformer extends TransformerAbstract
     {
         return [
             'id' => $user->sqid,
-            'name' => $user->name,
-            'email' => $user->email,
+            'name' => $user->display_name,
             'points' => $user->points,
             'created_at' => Carbon::parse($user->created_at)->toIso8601String()
         ];

--- a/config/flashcard.php
+++ b/config/flashcard.php
@@ -9,5 +9,6 @@ return [
         'easy' => 30,
         'medium' => 10080, // 7 days
         'hard' => 40320, // 28 days
-    ]
+    ],
+    'free_account_limit' => 10,
 ];

--- a/database/migrations/2025_02_27_080652_create_role_table.php
+++ b/database/migrations/2025_02_27_080652_create_role_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use App\Models\Role;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('roles', function (Blueprint $table) {
+            $table->id();
+            $table->string('name', 64);
+            $table->string('code', 64);
+        });
+
+        Role::create([
+            'name' => 'User',
+            'code' => 'user',
+        ]);
+
+        Role::create([
+            'name' => 'Advanced user',
+            'code' => 'advanced_user',
+        ]);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('role');
+    }
+};

--- a/database/migrations/2025_02_27_081047_create_role_user_table.php
+++ b/database/migrations/2025_02_27_081047_create_role_user_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use App\Models\Role;
+use App\Models\User;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('role_user', function (Blueprint $table) {
+            $table->id();
+            $table->foreignIdFor(Role::class);
+            $table->foreignIdFor(User::class);
+            $table->dateTime('valid_until')->nullable();
+            $table->boolean('auto_renew')->default(false);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('role_user');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -2,7 +2,6 @@
 
 namespace Database\Seeders;
 
-use App\Models\Role;
 use App\Models\User;
 use Illuminate\Database\Seeder;
 
@@ -14,7 +13,5 @@ class DatabaseSeeder extends Seeder
             'username' => 'demo',
             'display_name' => 'Demo user',
         ]);
-
-        $demo->roles()->attach([Role::where('code', 'user')->first()]);
     }
 }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -2,6 +2,7 @@
 
 namespace Database\Seeders;
 
+use App\Models\Role;
 use App\Models\User;
 use Illuminate\Database\Seeder;
 
@@ -9,8 +10,11 @@ class DatabaseSeeder extends Seeder
 {
     public function run(): void
     {
-        $user = User::factory()->create([
-            'username' => 'tester'
+        $demo = User::factory()->create([
+            'username' => 'tester',
+            'display_name' => 'Demo user',
         ]);
+
+        $demo->roles()->attach([Role::where('code', 'user')->first()]);
     }
 }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -11,7 +11,7 @@ class DatabaseSeeder extends Seeder
     public function run(): void
     {
         $demo = User::factory()->create([
-            'username' => 'tester',
+            'username' => 'demo',
             'display_name' => 'Demo user',
         ]);
 

--- a/tests/Unit/UserTest.php
+++ b/tests/Unit/UserTest.php
@@ -2,7 +2,10 @@
 
 namespace Tests\Unit;
 
+use App\Models\Role;
+use App\Models\RoleUser;
 use App\Models\User;
+use Carbon\Carbon;
 use Database\Factories\UserFactory;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -61,5 +64,65 @@ class UserTest extends TestCase
         $user = UserFactory::new()->losePoints()->create();
 
         $this->assertTrue($user->lose_points);
+    }
+
+    #[Test]
+    public function role_has_name_and_code()
+    {
+        $name = 'Test Role';
+        $code = 'test-role';
+        $role = Role::create([
+            'name' => $name,
+            'code' => $code
+        ]);
+
+        $this->assertEquals($name, $role->name);
+        $this->assertEquals($code, $role->code);
+    }
+
+    #[Test]
+    public function role_user_pivot_has_valid_until_and_auto_renew()
+    {
+        $role = Role::create([
+            'name' => 'Test Role',
+            'code' => 'test-role',
+        ]);
+
+        $user = UserFactory::new()->create();
+
+        $user->roles()->attach($role, [
+            'valid_until' => Carbon::now()->addDays(30),
+            'auto_renew' => true,
+        ]);
+
+        foreach($user->roles as $role) {
+            $this->assertEquals(Carbon::now()->addDays(30), $role->pivot->valid_until);
+            $this->assertTrue($role->pivot->auto_renew === 1);
+        }
+    }
+
+    #[Test]
+    public function role_user_pivot_can_be_updated()
+    {
+        $role = new Role();
+        $role->name = 'Test Role';
+        $role->code = 'test-role';
+
+        $user = UserFactory::new()->create();
+
+        $user->roles()->attach($user, [
+            'valid_until' => Carbon::now()->addDays(30),
+            'auto_renew' => true,
+        ]);
+
+        $newValidity = Carbon::now()->addDays(60);
+
+        foreach ($user->roles as $role) {
+            $role->pivot->valid_until = $newValidity;
+            $role->pivot->auto_renew = false;
+
+            $this->assertEquals($newValidity, $role->pivot->valid_until);
+            $this->assertEquals(0, $role->pivot->auto_renew);
+        }
     }
 }

--- a/tests/Unit/UserTest.php
+++ b/tests/Unit/UserTest.php
@@ -89,16 +89,17 @@ class UserTest extends TestCase
         ]);
 
         $user = UserFactory::new()->create();
+        $validity = Carbon::now()->addDays(30);
 
         $user->roles()->attach($role, [
-            'valid_until' => Carbon::now()->addDays(30),
+            'valid_until' => $validity,
             'auto_renew' => true,
         ]);
 
-        foreach($user->roles as $role) {
-            $this->assertEquals(Carbon::now()->addDays(30), $role->pivot->valid_until);
-            $this->assertTrue($role->pivot->auto_renew === 1);
-        }
+        $roleToCheck = $user->roles->where('code', 'test-role')->first();
+
+        $this->assertEquals($validity, $roleToCheck->pivot->valid_until);
+        $this->assertTrue($roleToCheck->pivot->auto_renew === 1);
     }
 
     #[Test]


### PR DESCRIPTION
Adds a free user and advanced user account.
Free accounts can create up to 10 questions. The advanced role removes this restriction. The limit itself is a configuration value, so you can change it to whatever makes the most sense to you.

I also updated some of the bit related to the `questions.json` importer, since that user will (probably) have more than 10 questions. At least they do in my dataset - they have about 200 😅 

And a couple of bugfixes:
1. Incorrect attributes being returned on the user response - made sense to address it without this feature, since I also want to get the roles they have in the response
2. `lost_points` was not a fillable attribute on the User mode, this is now resolved