### PR TITLE
Feat: return number of questions the user has created

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -82,7 +82,10 @@ class UserController extends Controller
     {
         return response()->json([
             'data' => [
-                'count' => $request->user()->flashcards()->count()
+                'count' => $request->user()->flashcards()->count(),
+                'remaining' => $request->user()->roles()->where('code', 'advanced_user')->exists()
+                    ? null
+                    : config('flashcards.free_account_limit') - $request->user()->flashcards()->count()
             ]
         ]);
     }

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Controllers;
 
-use App\Helpers\ApiResponse;
 use App\Models\User;
 use App\Transformers\UserTransformer;
 use Illuminate\Http\JsonResponse;
@@ -60,17 +59,31 @@ class UserController extends Controller
      *     tags={"auth"},
      *     @OA\Parameter(name="user", in="path", @OA\Schema(type="integer")),
      *     @OA\Response(response="200", description="Success"),
+     *     @OA\Response(response="401", description="Unauthorised"),
      *     security={{"bearerAuth":{}}}
      * )
      */
     public function show(Request $request): JsonResponse
     {
-        $user = $request->user();
+        return fractal($request->user(), new UserTransformer())->respond();
+    }
 
-        if (!$user) {
-            return ApiResponse::error('Not found', 'User not found', 'not_found', 404);
-        }
-
-        return fractal($user, new UserTransformer())->respond();
+    /**
+     * @OA\Get(
+     *     path="/api/user/count_questions",
+     *     summary="Get the number of flashcards the user has made",
+     *     tags={"auth"},
+     *     @OA\Response(response="200", description="Success"),
+     *     @OA\Response(response="401", description="Unauthorised"),
+     *     security={{"bearerAuth":{}}}
+     * )
+     */
+    public function countQuestions(Request $request): JsonResponse
+    {
+        return response()->json([
+            'data' => [
+                'count' => $request->user()->flashcards()->count()
+            ]
+        ]);
     }
 }

--- a/app/Transformers/UserTransformer.php
+++ b/app/Transformers/UserTransformer.php
@@ -17,6 +17,7 @@ class UserTransformer extends TransformerAbstract
             'name' => $user->display_name,
             'points' => $user->points,
             'created_at' => Carbon::parse($user->created_at)->toIso8601String(),
+            'question_count' => $user->flashcards()->count(),
             'options' => [
                 'easy_time' => $user->easy_time,
                 'medium_time' => $user->medium_time,

--- a/config/flashcard.php
+++ b/config/flashcard.php
@@ -10,5 +10,5 @@ return [
         'medium' => 10080, // 7 days
         'hard' => 40320, // 28 days
     ],
-    'free_account_limit' => 10,
+    'free_account_limit' => 20,
 ];

--- a/routes/api.php
+++ b/routes/api.php
@@ -5,12 +5,17 @@ use App\Http\Controllers\AttemptController;
 use App\Http\Controllers\FlashcardController;
 use App\Http\Controllers\FlashcardTagController;
 use App\Http\Controllers\TagController;
+use App\Http\Controllers\UserController;
 use App\Http\Middleware\CheckAuthed;
 use Illuminate\Support\Facades\Route;
 
 Route::post('/register', 'App\Http\Controllers\UserController@register')->name('auth.register');
 Route::post('/login', 'App\Http\Controllers\LoginController@login')->name('auth.login');
-Route::get('/user', 'App\Http\Controllers\UserController@show')->middleware('auth:sanctum')->name('auth.user');
+
+Route::controller(UserController::class)->prefix('user')->middleware(['auth:sanctum', CheckAuthed::class])->group(function () {
+    Route::get('/', 'show')->name('auth.user');
+    Route::get('/count_questions', 'countQuestions')->name('user.questions');
+});
 
 Route::controller(AnswerController::class)->prefix('answers')->middleware(['auth:sanctum', CheckAuthed::class])->group(function () {
     Route::post('/', 'store')->name('answers.store');

--- a/tests/Feature/UserControllerTest.php
+++ b/tests/Feature/UserControllerTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class UserControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_register_valid_request()
+    {
+        $response = $this->postJson('/api/register', [
+            'username' => 'testuser',
+            'password' => 'password',
+            'password_confirmation' => 'password',
+            'display_name' => 'Test User',
+        ]);
+
+        $response->assertStatus(201);
+        $this->assertCount(1, User::all());
+    }
+
+    public function test_register_invalid_request()
+    {
+        $response = $this->postJson('/api/register', [
+            'username' => 'testuser',
+            'password' => 'password',
+            'display_name' => 'Test User',
+        ]);
+
+        $response->assertStatus(422);
+        $this->assertCount(0, User::all());
+    }
+
+    public function test_show_logged_in_user()
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        $response = $this->getJson('/api/user');
+
+        $response->assertStatus(200);
+        $this->assertEquals($user->sqid, $response['data']['id']);
+        $this->assertEquals($user->username, $response['data']['username']);
+        $this->assertEquals($user->display_name, $response['data']['name']);
+    }
+
+    public function test_show_unauthorized()
+    {
+        $response = $this->getJson('/api/user');
+
+        $response->assertStatus(401);
+    }
+
+    public function test_count_questions()
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        $response = $this->getJson('/api/user/count_questions');
+
+        $response->assertStatus(200);
+        $this->assertEquals(0, $response['data']['count']);
+    }
+}

--- a/tests/Feature/UserControllerTest.php
+++ b/tests/Feature/UserControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use App\Models\Flashcard;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -55,7 +56,7 @@ class UserControllerTest extends TestCase
         $response->assertStatus(401);
     }
 
-    public function test_count_questions()
+    public function test_count_trial_user_questions()
     {
         $user = User::factory()->create();
         $this->actingAs($user);
@@ -64,5 +65,31 @@ class UserControllerTest extends TestCase
 
         $response->assertStatus(200);
         $this->assertEquals(0, $response['data']['count']);
+        $this->assertEquals(config('flashcards.free_account_limit'), $response['data']['remaining']);
+    }
+
+    public function test_count_trial_user_questions_with_some_utilisation()
+    {
+        $user = User::factory()->create();
+        $flashcards = Flashcard::factory()->count(2)->create(['user_id' => $user->id]);
+        $this->actingAs($user);
+
+        $response = $this->getJson('/api/user/count_questions');
+
+        $response->assertStatus(200);
+        $this->assertEquals($flashcards->count(), $response['data']['count']);
+        $this->assertEquals(config('flashcards.free_account_limit') - $flashcards->count(), $response['data']['remaining']);
+    }
+
+    public function test_count_advanced_user_questions()
+    {
+        $user = User::factory()->hasRoles(1, ['name' => 'Advanced user', 'code' => 'advanced_user'])->create();
+        $this->actingAs($user);
+
+        $response = $this->getJson('/api/user/count_questions');
+
+        $response->assertStatus(200);
+        $this->assertEquals(0, $response['data']['count']);
+        $this->assertNull($response['data']['remaining']);
     }
 }


### PR DESCRIPTION
On the user response:
- Return the number of questions they have created

A new endpoint specifically for getting the counts of how many questions the user has created AND how many they have remaining. In the case of an advanced user, the remaining count will always be null.